### PR TITLE
Fixed precision argument

### DIFF
--- a/num.js
+++ b/num.js
@@ -15,20 +15,42 @@ function Num(num, prec) {
     // convert to a string
     num = '' + num;
 
+    var currentPrecision = 0;
+
     // find Num point
     var dec = num.indexOf('.');
+    num = num.replace('.', '');
 
-    if (dec >= 0) {
-        // take out the Num point
-        num = num.replace('.', '');
-        var precision = num.length - dec;
+    if (dec >= 0)
+    {
+        currentPrecision = num.length - dec;
     }
-    else {
-        var precision = 0;
+
+    if (isNaN(prec))
+    {
+        this._precision = currentPrecision;
+    }
+    else
+    {
+        // Pad with zero as needed
+        if (prec > currentPrecision)
+        {
+            var zeroWidth = prec - currentPrecision + 1;
+            if (zeroWidth > 1)
+            {
+                num = num + new Array(zeroWidth).join('0');
+            }
+        }
+        else
+        {
+            // Trim
+            num = num.substr(0, num.length - (currentPrecision - prec));
+        }
+
+        this._precision = prec;
     }
 
     this._int = int(num);
-    this._precision = prec || precision;
 }
 
 // TODO (shtylman) cleanup


### PR DESCRIPTION
Following up on Issue #2, here's a suggested fix. 

The test I did:

``` javascript
console.log(Num('0', 2).toString()); // 0.00
console.log(Num('.0', 2).toString()); // 0.00
console.log(Num('.1', 2).toString()); // 0.10
console.log(Num('0.1', 2).toString()); // 0.10
console.log(Num('1.1', 2).toString()); // 1.10
console.log(Num('1', 2).toString()); // 1.00
console.log(Num('1.0', 2).toString()); // 1.00
console.log(Num('1.11', 2).toString()); // 1.11
console.log(Num('1.1111', 2).toString()); // 1.11
console.log(Num('1234', 2).toString()); // 1234.00
```
