### PR TITLE
Best effort valueOf to support lossy operation

### DIFF
--- a/num.js
+++ b/num.js
@@ -66,7 +66,12 @@ Num.prototype.toString = function() {
     return (neg ? '-' : '') + before_dot + '.' + zeros + num_str.slice(idx);
 };
 
-Num.prototype.valueOf = Num.prototype.toString;
+/// return an approximate primitive value so that numeric operations
+/// are not treated as string operations
+Num.prototype.valueOf = function() {
+    return parseFloat(this.toString());
+}
+
 Num.prototype.toJSON = Num.prototype.toString;
 
 /// return {int} the precision

--- a/test/toString.js
+++ b/test/toString.js
@@ -1,0 +1,8 @@
+
+var assert = require('assert');
+var num = require('../');
+
+test('toString', function() {
+    assert.equal(num('12345678912345.6789123456789').toString(), '12345678912345.6789123456789');
+});
+

--- a/test/valueOf.js
+++ b/test/valueOf.js
@@ -1,0 +1,19 @@
+
+var assert = require('assert');
+var num = require('../');
+
+test('valueOf', function() {
+    assert.equal(num(123).valueOf(), 123);
+    assert.equal(num(-3.1415).valueOf(), -3.1415);
+    assert.equal(num(123) + 123, 246);
+    assert.equal(num(123) * 2, 246);
+    assert.equal(num(123) / 2, 61.5);
+    assert.equal(num(123) - 123, 0);
+
+    assert.equal(num('3.14'), 3.14);
+    assert.ok(num('3.14') == 3.14);
+
+    assert.equal(num('9223372036854775808'), 9223372036854776000);
+    assert.ok(num('9223372036854775808') == 9223372036854776000);
+});
+


### PR DESCRIPTION
Suppose someone either intentionally or unintentionally does num1 + num2 instead of num1.add(num2), the operation should go through on a best effort basis.

Before this change, num1 + num2 ends up being string concatentation and the result is unusable.

I think returning a best effort lossy version of the number to support lossy +/-/*/div operations is more useful than returning the string representation.
